### PR TITLE
Fix Dockerfile to include workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,7 @@ RUN apt-get update -y && apt-get install -y ros-noetic-compressed-image-transpor
 RUN apt-get update -y && apt-get install -y python3-pip
 RUN pip install tensorflow keras torch
 WORKDIR /root/projects/
+
+COPY . .
+
 RUN echo 'catkin_make install && source /root/projects/devel/setup.bash' >> /root/.bashrc


### PR DESCRIPTION
The start_docker scripts currently load an image from dockerhub that was previously "not identical" to the one created by the Dockerfile, with the later being broken, as the catkin workspace was not copied in.

This commit fixes that issue, and makes the two "identical".

I understand that it is more complicated than that: _Technically speaking_ the images are identical. Instead, it is the way in which start-docker.sh runs the image that normally copies in the file structure. However, this is a bad way to do it that messed up my mind several times while trying to work on this project.

I also understand that pushing the image that is created like this to dockerhub technically breaks the current instructions (as students should now run the Dockerfile and the created image themselves instead of pulling from dockerhub and then copying local files in,) but that workflow is an esoteric mess I plan to change anyway.  