### PR TITLE
Add stop_wheels method to the Robobo interface

### DIFF
--- a/examples/full_project_setup/catkin_ws/src/robobo_interface/src/robobo_interface/base.py
+++ b/examples/full_project_setup/catkin_ws/src/robobo_interface/src/robobo_interface/base.py
@@ -80,6 +80,14 @@ class IRobobo(ABC):
         self.perform_blocking(
             functools.partial(self.move, left_speed, right_speed, millis)
         )
+    
+    def stop_wheels(self) -> int:
+        """Stops the robot's wheels
+        returns:
+            the blockid
+        """
+        return self.move(0, 0, 1000)
+
 
     @abstractmethod
     def reset_wheels(self) -> None:

--- a/maintained/catkin_ws/src/robobo_interface/src/robobo_interface/base.py
+++ b/maintained/catkin_ws/src/robobo_interface/src/robobo_interface/base.py
@@ -80,6 +80,14 @@ class IRobobo(ABC):
         self.perform_blocking(
             functools.partial(self.move, left_speed, right_speed, millis)
         )
+    
+    def stop_wheels(self) -> int:
+        """Stops the robot's wheels
+        returns:
+            the blockid
+        """
+        return self.move(0, 0, 1000)
+
 
     @abstractmethod
     def reset_wheels(self) -> None:


### PR DESCRIPTION
Robobo's interface has a fun quirk where it ignores move commands that are under 100ms even in instances where it doesn't matter, such as when trying to set the wheel speed to 0. 
To avoid running into this the new `stop_wheels` function calls move with a 1s move time.  This is the same move time as  the official [robobo.py](https://github.com/mintforpeople/robobo.py/blob/9f4de9d3ce398775f7307d9d6049bc04cda8ac1c/src/robobopy/Robobo.py#L95) library.