### PR TITLE
Hotfix: Fix issue with the ros image not building

### DIFF
--- a/examples/full_project_setup/Dockerfile
+++ b/examples/full_project_setup/Dockerfile
@@ -5,6 +5,21 @@ FROM ros:noetic
 EXPOSE 45100
 EXPOSE 45101
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 RUN apt-get update -y && apt-get install -y python3 python3-pip git && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies.

--- a/examples/hardware_setup/Dockerfile
+++ b/examples/hardware_setup/Dockerfile
@@ -1,5 +1,20 @@
 FROM ros:noetic
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 # These are some extra dependencies we need to use the Robobo, don't worry about it.
 RUN apt-get update -y && apt-get install ffmpeg libsm6 libxext6 ros-noetic-opencv-apps dos2unix -y && rm -rf /var/lib/apt/lists/*
 

--- a/examples/ros_basic_setup/Dockerfile
+++ b/examples/ros_basic_setup/Dockerfile
@@ -5,6 +5,21 @@ FROM ros:noetic
 EXPOSE 45100
 EXPOSE 45101
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 RUN apt-get update -y && apt-get install -y python3 python3-pip git && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies.

--- a/maintained/dockerfiles/full.dockerfile
+++ b/maintained/dockerfiles/full.dockerfile
@@ -5,6 +5,21 @@ FROM ros:noetic
 EXPOSE 45100
 EXPOSE 45101
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 RUN apt-get update -y && apt-get install -y python3 python3-pip git && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies.

--- a/maintained/dockerfiles/full_cached.dockerfile
+++ b/maintained/dockerfiles/full_cached.dockerfile
@@ -1,5 +1,20 @@
 FROM ros:noetic as base
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 RUN apt-get update -y && apt-get install -y python3 python3-pip git dos2unix && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies.

--- a/maintained/dockerfiles/hardware.dockerfile
+++ b/maintained/dockerfiles/hardware.dockerfile
@@ -1,5 +1,20 @@
 FROM ros:noetic
 
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+    && rm /usr/share/keyrings/ros1-latest-archive-keyring.gpg
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates curl
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros-apt-source.deb \
+    && rm -f /tmp/ros-apt-source.deb
+
+RUN apt-get update \
+    && apt-get install -y ros-noetic-roscpp-tutorials
+
 # These are some extra dependencies we need to use the Robobo, don't worry about it.
 RUN apt-get update -y && apt-get install ffmpeg libsm6 libxext6 ros-noetic-opencv-apps dos2unix -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The GPG key inside the ROS:noetic images experied on 2025-6-1 This meant the images could not use apt anymore, failing their builds.

Hotfix for this was copied over from here: https://github.com/osrf/docker_images/issues/807
The actual fix is being worked on here: https://github.com/docker-library/official-images/pull/19162

This commit can be reverted once the issue is solved upstream.